### PR TITLE
Switch json dependency to poison

### DIFF
--- a/lib/cloudos_auth/client.ex
+++ b/lib/cloudos_auth/client.ex
@@ -30,7 +30,7 @@ defmodule CloudosAuth.Client do
   """
   @spec get_token_raw(String.t(), String.t(), String.t()) :: {:ok, CloudosAuth.Token} | {:error, String.t()}
   def get_token_raw(url, client_id, client_secret) do
-    body = '#{JSON.encode!(%{
+    body = '#{Poison.encode!(%{
       grant_type: "client_credentials", 
       client_id: client_id, 
       client_secret: client_secret
@@ -39,8 +39,8 @@ defmodule CloudosAuth.Client do
     case :httpc.request(:post, {url, [{'Content-Type', 'application/json'}, {'Accept', 'application/json'}], 'application/json', body}, [], []) do
       {:ok, {{_,200, _}, _, body}} ->
         Logger.debug("Retrieved OAuth Token")
-        token = JSON.decode!("#{body}")["access_token"]
-        expiration = String.to_integer(JSON.decode!("#{body}")["expires_in"])
+        token = Poison.decode!("#{body}")["access_token"]
+        expiration = String.to_integer(Poison.decode!("#{body}")["expires_in"])
         timestamp = Util.timestamp_add_seconds(start_time, expiration)
         {:ok, %CloudosAuth.Token{token: token, expires_at: timestamp}}
       {:ok, {{_,return_code, _}, _, body}} ->

--- a/lib/cloudos_auth/server.ex
+++ b/lib/cloudos_auth/server.ex
@@ -28,7 +28,7 @@ defmodule CloudosAuth.Server do
               case return_code do
                 200 -> 
                   Logger.debug("Received response from OAuth:  #{inspect body}")
-                  userinfo_json = JSON.decode!("#{body}")
+                  userinfo_json = Poison.decode!("#{body}")
                   Logger.debug("Parsed OAuth response:  #{inspect userinfo_json}")
                   cond do
                     userinfo_json["expires_in_seconds"] == nil || userinfo_json["expires_in_seconds"] <= 0 ->

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule CloudosAuth.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:json, "0.3.0"},
+    [{:poison, "~>1.3.1"},
      {:exvcr, "~>0.3.3", only: :test},
      {:meck, "0.8.2", only: :test}]
   end


### PR DESCRIPTION
our other projects use Poison for JSON encoding/decoding, so switched this over as well. This also fixes the compilation warning:

`warning: the dependency json requires Elixir "~> 0.14" but you are running on v1.0.2`

That would show up.
